### PR TITLE
Minor Bug in bundle download

### DIFF
--- a/formation.go
+++ b/formation.go
@@ -574,7 +574,7 @@ func bundleFormation(formation cloud66.Formation, bundleFile string, envVars []c
 	//add helm releases
 	fmt.Println("Saving helm releases...")
 	for _, release := range formation.HelmReleases {
-		fileName := filepath.Join(releasesDir, release.ChartName+"-values.yml")
+		fileName := filepath.Join(releasesDir, release.DisplayName+"-values.yml")
 		file, err := os.Create(fileName)
 		defer file.Close()
 		if err != nil {


### PR DESCRIPTION
Values file prefix has to be the display name since it's unique in the formation while you can have two helm-chart from the same release. It was already fixed in the other code